### PR TITLE
Update token identifier in OperationsTokenIdInput

### DIFF
--- a/components/operations/operations-tokenid-input.tsx
+++ b/components/operations/operations-tokenid-input.tsx
@@ -13,7 +13,11 @@ export const OperationsTokenIdInput = ({
   tokenType: CommonOpertationContentProps['tokenType'];
   description?: string;
 }) => {
-  const { tokens } = useCreatorTokens<{ ticker: string; isPaused: boolean }>({
+  const { tokens } = useCreatorTokens<{
+    ticker: string;
+    identifier: string;
+    isPaused: boolean;
+  }>({
     tokenType,
   });
 
@@ -25,7 +29,7 @@ export const OperationsTokenIdInput = ({
       options={
         tokens
           ? tokens?.map((token) => ({
-              value: token.ticker,
+              value: token.identifier,
               label: token.ticker,
             }))
           : []


### PR DESCRIPTION
The ticker doesn't match the token identifier in some cases (I believe its when a token is "verified").

I don't know if you also want the label to be the token identifier value